### PR TITLE
Fix for sequelize >5.19

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const Sequelize = require('sequelize');
 
 module.exports = function (sequelize) {
   if (!sequelize) {
@@ -35,19 +36,20 @@ module.exports = function (sequelize) {
         return;
       }
       if (fieldDefinition.noUpdate['readOnly']) {
-        validationErrors.push(new sequelize.ValidationErrorItem('`' + fieldName + '` cannot be updated due `noUpdate:readOnly` constraint', 'readOnly Violation', fieldName, instance[fieldName]));
+        
+        validationErrors.push(new Sequelize.ValidationErrorItem('`' + fieldName + '` cannot be updated due `noUpdate:readOnly` constraint', 'readOnly Violation', fieldName, instance[fieldName]));
         return;
       }
       if (instance._previousDataValues[fieldName] !== undefined
           && instance._previousDataValues[fieldName] !== null) {
 
-        validationErrors.push(new sequelize.ValidationErrorItem('`' + fieldName + '` cannot be updated due `noUpdate` constraint', 'noUpdate Violation', fieldName, instance[fieldName]));
+        validationErrors.push(new Sequelize.ValidationErrorItem('`' + fieldName + '` cannot be updated due `noUpdate` constraint', 'noUpdate Violation', fieldName, instance[fieldName]));
       }
     });
 
     if (validationErrors.length) {
-      return sequelize.Promise.try(function () {
-        throw new sequelize.ValidationError(null, validationErrors);
+      return Sequelize.Promise.try(function () {
+        throw new Sequelize.ValidationError(null, validationErrors);
       });
     }
   });


### PR DESCRIPTION
Error: TypeError: sequelize.ValidationError is not a constructor
Solved importing class Sequelize and get constructor from there instead of sequelize (without capital)